### PR TITLE
Add Docker setup with health check indicator

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 axum = "0.8.4"
 tokio = { version = "1", features = ["full"] }
 askama = { version = "0.14.0" }
-tower-http = { version = "0.6.6", features = ["fs", "trace"] }
+tower-http = { version = "0.6.6", features = ["fs", "trace", "cors"] }
 serde = { version = "1.0.219", features = ["derive"] }
 confy = "1.0.0"
 tracing = "0.1"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:1.79-bullseye as builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock .
+COPY src src
+COPY templates templates
+COPY static static
+RUN cargo build --release
+
+FROM debian:bullseye-slim
+WORKDIR /app
+COPY --from=builder /app/target/release/dir-web /usr/local/bin/dir-web
+COPY templates templates
+COPY static static
+EXPOSE 3000
+CMD ["dir-web"]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -9,6 +9,7 @@ use axum::{
 use confy::ConfyError;
 use serde::{Deserialize, Serialize};
 use tower_http::{
+    cors::CorsLayer,
     services::ServeDir,
     trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
 };
@@ -46,10 +47,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .on_request(DefaultOnRequest::new().level(Level::INFO))
         .on_response(DefaultOnResponse::new().level(Level::INFO));
 
+    let cors = CorsLayer::permissive();
+
     let app = Router::new()
         .route("/", get(home))
         .route("/health", get(health))
         .route("/directory", get(list_things))
+        .layer(cors)
         .layer(trace)
         .nest_service("/static", ServeDir::new("static"));
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - '3000:3000'
+  frontend:
+    build: ./frontend
+    environment:
+      - VITE_API_URL=http://backend:3000
+    ports:
+      - '5173:5173'
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { http } from './lib/http'
+import { http, API_BASE } from './lib/http'
 
 type Item = { id: number; name: string }
 
@@ -16,9 +16,27 @@ export default function App() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ['items'] }),
   })
 
+  const health = useQuery({
+    queryKey: ['health'],
+    queryFn: () =>
+      fetch(`${API_BASE}/health`).then(res => {
+        if (!res.ok) throw new Error('unhealthy')
+        return res.text()
+      }),
+    refetchInterval: 5000,
+    retry: false,
+  })
+
   return (
     <div style={{ padding: 24, fontFamily: 'system-ui' }}>
       <h1>React ↔ Rust (REST)</h1>
+      {health.isLoading ? (
+        <p>Checking backend…</p>
+      ) : (
+        <p style={{ color: health.isError ? 'red' : 'green' }}>
+          {health.isError ? 'Backend unhealthy' : 'Backend healthy'}
+        </p>
+      )}
       <button
         onClick={() => addItem.mutate(`Item ${Date.now()}`)}
         disabled={addItem.isPending}


### PR DESCRIPTION
## Summary
- enable CORS in the Rust backend and expose a /health route
- show backend health status in the React frontend
- provide Dockerfiles and docker-compose to run frontend and backend together

## Testing
- `cargo test`
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc50cd41f08331b5914f5f77e9133d