### PR TITLE
feat: scaffold frontend layout for directory explorer

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,67 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+.app-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  font-family: system-ui;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.path-bar {
+  padding: 8px 12px;
+  border-bottom: 1px solid #ccc;
+  background: #f5f5f5;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.breadcrumbs span {
+  cursor: pointer;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
+.breadcrumbs .separator {
+  margin: 0 4px;
   color: #888;
+}
+
+.health {
+  margin-left: 12px;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.sidebar {
+  width: 200px;
+  border-right: 1px solid #ddd;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar li {
+  margin-bottom: 4px;
+}
+
+.sidebar .link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: #06c;
+  cursor: pointer;
+}
+
+.main {
+  flex: 1;
+  padding: 16px;
+  overflow-y: auto;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,28 +1,74 @@
-import { useQuery } from '@tanstack/react-query'
-import { API_BASE } from './lib/http'
+import { useState, useMemo, useEffect } from 'react';
+import type { DirectoryNode } from './types';
+import { MOCK_FS } from './mockData';
+import { API_BASE } from './lib/http';
+import './App.css';
+
+function getDirectory(root: DirectoryNode, path: string[]): DirectoryNode {
+  let current = root;
+  for (let i = 1; i < path.length; i++) {
+    const segment = path[i];
+    const next = current.children.find(
+      c => c.type === 'directory' && c.name === segment
+    ) as DirectoryNode | undefined;
+    if (!next) break;
+    current = next;
+  }
+  return current;
+}
 
 export default function App() {
-  const health = useQuery({
-    queryKey: ['health'],
-    queryFn: () =>
-      fetch(`${API_BASE}/health`).then(res => {
-        if (!res.ok) throw new Error('unhealthy')
-        return res.text()
-      }),
-    refetchInterval: 5000,
-    retry: false,
-  })
+  const [path, setPath] = useState<string[]>([MOCK_FS.name]);
+  const [health, setHealth] = useState<'healthy' | 'unhealthy'>('unhealthy');
+
+  const currentDir = useMemo(() => getDirectory(MOCK_FS, path), [path]);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/health`)
+      .then(res => res.text())
+      .then(text => setHealth(text.trim() === 'healthy' ? 'healthy' : 'unhealthy'))
+      .catch(() => setHealth('unhealthy'));
+  }, []);
 
   return (
-    <div style={{ padding: 24, fontFamily: 'system-ui' }}>
-      <h1>React ↔ Rust (REST)</h1>
-      {health.isLoading ? (
-        <p>Checking backend…</p>
-      ) : (
-        <p style={{ color: health.isError ? 'red' : 'green' }}>
-          {health.isError ? 'Backend unhealthy' : 'Backend healthy'}
-        </p>
-      )}
+    <div className="app-container">
+      <div className="path-bar">
+        <div className="breadcrumbs">
+          {path.map((segment, idx) => {
+            const fullPath = path.slice(0, idx + 1).join('/');
+            return (
+              <span key={fullPath} onClick={() => setPath(path.slice(0, idx + 1))}>
+                {segment}
+                {idx < path.length - 1 && <span className="separator">/</span>}
+              </span>
+            );
+          })}
+        </div>
+        <span className="health">{health}</span>
+      </div>
+      <div className="content">
+        <aside className="sidebar">
+          <ul>
+            {currentDir.children.map(child => (
+              <li key={child.name}>
+                {child.type === 'directory' ? (
+                  <button className="link" onClick={() => setPath([...path, child.name])}>
+                    {child.name}/
+                  </button>
+                ) : (
+                  child.name
+                )}
+              </li>
+            ))}
+          </ul>
+        </aside>
+        <main className="main">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua.
+          </p>
+        </main>
+      </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/frontend/src/mockData.ts
+++ b/frontend/src/mockData.ts
@@ -1,0 +1,18 @@
+import type { DirectoryNode } from './types';
+
+export const MOCK_FS: DirectoryNode = {
+  name: 'root',
+  type: 'directory',
+  children: [
+    {
+      name: 'src',
+      type: 'directory',
+      children: [
+        { name: 'index.ts', type: 'file' },
+        { name: 'App.tsx', type: 'file' },
+      ],
+    },
+    { name: 'package.json', type: 'file' },
+    { name: 'README.md', type: 'file' },
+  ],
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,12 @@
+export interface FileNode {
+  name: string;
+  type: 'file';
+}
+
+export interface DirectoryNode {
+  name: string;
+  type: 'directory';
+  children: Node[];
+}
+
+export type Node = FileNode | DirectoryNode;


### PR DESCRIPTION
## Summary
- add typed file system models and mock data
- render breadcrumb path bar with clickable segments and health status
- show directory contents in sidebar with placeholder main pane

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bc672888888331bbc7a62b7169ff99